### PR TITLE
React-router-integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@
 /public/packs
 /public/packs-test
 
+# Ignore frontend build output.
+/public/frontend
+
 # Ignore node modules.
 /node_modules
 /yarn-error.log

--- a/app/controllers/concerns/player_authentication.rb
+++ b/app/controllers/concerns/player_authentication.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# PlayerAuthentication concern
+#
+# Cookie-based Player authentication for re2q application.
+# Automatically creates a Player record and sets an encrypted cookie
+# for anonymous user tracking.
+#
+# Usage:
+#   class MyController < ApplicationController
+#     include PlayerAuthentication
+#
+#     def index
+#       player = find_or_create_player_from_cookie
+#       # or use current_player after calling ensure_player_authenticated
+#     end
+#   end
+module PlayerAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    # Optional: uncomment to automatically authenticate on all actions
+    # before_action :ensure_player_authenticated
+  end
+
+  # Get or create player from cookie and set as current_player
+  def ensure_player_authenticated
+    @current_player = find_or_create_player_from_cookie
+  end
+
+  # Returns the authenticated player (call ensure_player_authenticated first)
+  def current_player
+    @current_player
+  end
+
+  private
+
+  # Cookie から player を取得または作成
+  def find_or_create_player_from_cookie
+    player_uuid = cookies.encrypted[:player_uuid]
+
+    if player_uuid.blank?
+      # 新規 Player を作成
+      create_new_player
+    else
+      # 既存の Player を取得（存在しない場合は新規作成）
+      find_existing_player_or_create(player_uuid)
+    end
+  end
+
+  # 新規 Player を作成し、Cookie を設定
+  def create_new_player
+    player = Player.create!(uuid: SecureRandom.uuid)
+    set_player_cookie(player.uuid)
+    player
+  end
+
+  # 既存の Player を取得、存在しない場合は新規作成
+  def find_existing_player_or_create(player_uuid)
+    player = Player.find_by(uuid: player_uuid)
+    if player.nil?
+      player = Player.create!(uuid: SecureRandom.uuid)
+      set_player_cookie(player.uuid)
+    end
+    player
+  end
+
+  # Player Cookie を設定
+  def set_player_cookie(player_uuid)
+    cookies.encrypted[:player_uuid] = {
+      value: player_uuid,
+      expires: 1.day.from_now,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax  # クロスオリジンリクエストでもcookieを送信可能に
+    }
+  end
+end

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -2,6 +2,6 @@
 
 class FrontendController < ApplicationController
   def show
-    render file: Rails.root.join("public", "frontend", "index.html"), layout: false
+    render file: Rails.root.join("public", "frontend", "frontend-index.html"), layout: false
   end
 end

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FrontendController < ApplicationController
+  def show
+    render file: Rails.root.join("public", "frontend", "index.html"), layout: false
+  end
+end

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -4,7 +4,7 @@ class FrontendController < ApplicationController
   include PlayerAuthentication
 
   # /frontend/admin 以外のアクセス時に Player を認証
-  before_action :authenticate_player_for_non_admin, only: [:show]
+  before_action :authenticate_player_for_non_admin, only: [ :show ]
 
   def show
     render file: Rails.root.join("public", "frontend", "frontend-index.html"), layout: false

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
 class FrontendController < ApplicationController
+  include PlayerAuthentication
+
+  # /frontend/admin 以外のアクセス時に Player を認証
+  before_action :authenticate_player_for_non_admin, only: [:show]
+
   def show
     render file: Rails.root.join("public", "frontend", "frontend-index.html"), layout: false
+  end
+
+  private
+
+  # /admin パス以外の場合に Player 認証を実行
+  def authenticate_player_for_non_admin
+    # /frontend/admin へのアクセスは認証をスキップ
+    return if request.path.start_with?("/frontend/admin")
+
+    # Player を取得または作成し、Cookie を設定
+    ensure_player_authenticated
   end
 end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class GraphqlController < ApplicationController
+  include PlayerAuthentication
+
   # CSRF protection exemption for GraphQL API
   # Cookie-based authentication is still functional
   skip_before_action :verify_authenticity_token
@@ -27,38 +29,6 @@ class GraphqlController < ApplicationController
   end
 
   private
-
-  # Cookie から player を取得または作成
-  def find_or_create_player_from_cookie
-    player_uuid = cookies.encrypted[:player_uuid]
-
-    if player_uuid.blank?
-      # 新規 Player を作成
-      player = Player.create!(uuid: SecureRandom.uuid)
-      cookies.encrypted[:player_uuid] = {
-        value: player.uuid,
-        expires: 1.day.from_now,
-        httponly: true,
-        secure: Rails.env.production?,
-        same_site: :lax  # クロスオリジンリクエストでもcookieを送信可能に
-      }
-      player
-    else
-      # 既存の Player を取得（存在しない場合は新規作成）
-      player = Player.find_by(uuid: player_uuid)
-      if player.nil?
-        player = Player.create!(uuid: SecureRandom.uuid)
-        cookies.encrypted[:player_uuid] = {
-          value: player.uuid,
-          expires: 1.day.from_now,
-          httponly: true,
-          secure: Rails.env.production?,
-          same_site: :lax  # クロスオリジンリクエストでもcookieを送信可能に
-        }
-      end
-      player
-    end
-  end
 
   # Handle variables in form data, JSON body, or a blank value
   def prepare_variables(variables_param)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,7 +4,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "http://localhost:5173", "http://localhost:5174" # フロントエンドのURL
+    origins "http://localhost:3000", "https://re2q.smalruby.app" # フロントエンドのURL
 
     resource "/graphql",
       headers: :any,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  # React SPA frontend
+  get "frontend", to: "frontend#show"
+  get "frontend/*path", to: "frontend#show"
+
+  # Redirect root to frontend
+  root to: redirect("/frontend")
 end

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "next-themes": "^0.4.6",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "react-router-dom": "^7.9.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -3223,6 +3224,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4410,6 +4420,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.4.tgz",
+      "integrity": "sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.4.tgz",
+      "integrity": "sha512-f30P6bIkmYvnHHa5Gcu65deIXoA2+r3Eb6PJIAddvsT9aGlchMatJ51GgpU470aSqRRbFX22T70yQNUGuW3DfA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -4541,6 +4589,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "next-themes": "^0.4.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "react-router-dom": "^7.9.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useQuery as useApolloQuery, useMutation as useApolloMutation } from '@apollo/client/react'
+import { Routes, Route } from 'react-router-dom'
 import './App.css'
 import { AnswerScreen } from './components/AnswerScreen'
 import { AdminLogin } from './components/AdminLogin'
@@ -93,34 +94,36 @@ function AppContent() {
     return <Box p="20px" textAlign="center"><Text>Loading...</Text></Box>;
   }
 
-  // /admin パスの場合は管理画面を表示
-  if (window.location.pathname === '/admin') {
-    return admin ? (
-      <QuizControlPanel />
-    ) : (
-      <AdminLogin />
-    );
-  }
-
-  // 利用者画面
-  if (error) {
-    return (
-      <div style={{ padding: '20px', textAlign: 'center' }}>
-        <h2>エラーが発生しました</h2>
-        <p>{error.message}</p>
-      </div>
-    );
-  }
-
   return (
-    <AnswerScreen
-      me={data?.me || null}
-      quizState={data?.currentQuizState || null}
-      answers={data?.myAnswers || []}
-      onSubmitAnswer={handleSubmitAnswer}
-      onCooldownEnd={handleCooldownEnd}
-      loading={loading && !data}
-    />
+    <Routes>
+      {/* 管理者画面: /frontend/admin */}
+      <Route
+        path="/admin"
+        element={admin ? <QuizControlPanel /> : <AdminLogin />}
+      />
+
+      {/* 利用者画面: /frontend/ */}
+      <Route
+        path="/"
+        element={
+          error ? (
+            <div style={{ padding: '20px', textAlign: 'center' }}>
+              <h2>エラーが発生しました</h2>
+              <p>{error.message}</p>
+            </div>
+          ) : (
+            <AnswerScreen
+              me={data?.me || null}
+              quizState={data?.currentQuizState || null}
+              answers={data?.myAnswers || []}
+              onSubmitAnswer={handleSubmitAnswer}
+              onCooldownEnd={handleCooldownEnd}
+              loading={loading && !data}
+            />
+          )
+        }
+      />
+    </Routes>
   );
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import { ApolloProvider } from '@apollo/client/react'
 import { Provider } from '@/components/ui/provider'
 import './index.css'
@@ -10,7 +11,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider>
       <ApolloProvider client={client}>
-        <App />
+        <BrowserRouter basename="/frontend">
+          <App />
+        </BrowserRouter>
       </ApolloProvider>
     </Provider>
   </StrictMode>,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
   build: {
     outDir: '../public/frontend',
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash].[ext]',
+      },
+    },
   },
   resolve: {
     alias: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,11 @@ import path from 'path'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/frontend/',
+  build: {
+    outDir: '../public/frontend',
+    emptyOutDir: true,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/lib/tasks/frontend.rake
+++ b/lib/tasks/frontend.rake
@@ -48,6 +48,15 @@ namespace :frontend do
       system("npm", "run", "build")
     end
 
+    # Rename index.html to frontend-index.html to prevent direct browser access
+    # (must be accessed via FrontendController)
+    index_path = "#{Dir.pwd}/public/frontend/index.html"
+    renamed_path = "#{Dir.pwd}/public/frontend/frontend-index.html"
+    if File.exist?(index_path)
+      FileUtils.mv(index_path, renamed_path)
+      puts "Renamed index.html to frontend-index.html"
+    end
+
     puts "✅ React app successfully built and deployed!"
   end
 

--- a/lib/tasks/frontend.rake
+++ b/lib/tasks/frontend.rake
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+namespace :frontend do
+  # For convenience, npm packages do not have to be explicitly installed.
+  # Installed will be automatically initiated by other tasks.
+  desc "Install npm packages for the React app"
+  task :npm_install do
+    puts "Installing npm packages ..."
+    Dir.chdir("#{Dir.pwd}/frontend") do
+      system("npm", "install")
+    end
+  end
+
+  # Run bin/rails frontend:dev to start the dev server.
+  #
+  # If you are using the Foreman gem, you might want to run
+  # this task in the Procfile.
+  #
+  # bin/rails frontend:dev
+  desc "Start React Development Server with Hot Module Reloading"
+  task dev: [:npm_install] do
+    puts "Starting React app development server..."
+    Dir.chdir("#{Dir.pwd}/frontend") do
+      system("npm", "run", "dev")
+    end
+  end
+
+  # bin/rails frontend:typecheck
+  desc "Check Typescript for the React App"
+  task typecheck: [:npm_install] do
+    puts "Check Typescript for React app..."
+    Dir.chdir("#{Dir.pwd}/frontend") do
+      system("npm", "run", "typecheck")
+    end
+  end
+
+  # Run bin/rails frontend:build to build the production app.
+  # The location of the build is defined in the
+  # frontend/vite.config.ts file, and should
+  # point to a location within the public folder.
+  # Running bin/rails assets:precompile will also run this task.
+  #
+  # bin/rails frontend:build
+  desc "Build React App and move to the public folder"
+  task build: [:npm_install] do
+    puts "Building React app..."
+    Dir.chdir("#{Dir.pwd}/frontend") do
+      system("npm", "run", "build")
+    end
+
+    puts "✅ React app successfully built and deployed!"
+  end
+
+  # Run bin/rails frontend:preview to create a preview build.
+  #
+  # This is identical to running bin/rails frontend:build
+  # and is provided solely to align better with intent.
+  desc "Preview your React App from the Rails development server (typically port 3000)"
+  task preview: [:build]
+
+  # Run bin/rails frontend:clobber to remove the build files.
+  # Running bin/rails assets:clobber will also run this task.
+  task :clobber do
+    puts "Clobbering React app build files..."
+    FileUtils.rm_rf("#{Dir.pwd}/public/frontend")
+  end
+end
+
+# The following adds the above tasks to the regular
+# assets:precompile and assets:clobber tasks.
+#
+# This means that any normal Rails deployment script which
+# contains rake assets:precompile will also build the
+# React app automatically.
+Rake::Task["assets:precompile"].enhance(["frontend:build"])
+Rake::Task["assets:clobber"].enhance(["frontend:clobber"])

--- a/lib/tasks/frontend.rake
+++ b/lib/tasks/frontend.rake
@@ -18,7 +18,7 @@ namespace :frontend do
   #
   # bin/rails frontend:dev
   desc "Start React Development Server with Hot Module Reloading"
-  task dev: [:npm_install] do
+  task dev: [ :npm_install ] do
     puts "Starting React app development server..."
     Dir.chdir("#{Dir.pwd}/frontend") do
       system("npm", "run", "dev")
@@ -27,7 +27,7 @@ namespace :frontend do
 
   # bin/rails frontend:typecheck
   desc "Check Typescript for the React App"
-  task typecheck: [:npm_install] do
+  task typecheck: [ :npm_install ] do
     puts "Check Typescript for React app..."
     Dir.chdir("#{Dir.pwd}/frontend") do
       system("npm", "run", "typecheck")
@@ -42,7 +42,7 @@ namespace :frontend do
   #
   # bin/rails frontend:build
   desc "Build React App and move to the public folder"
-  task build: [:npm_install] do
+  task build: [ :npm_install ] do
     puts "Building React app..."
     Dir.chdir("#{Dir.pwd}/frontend") do
       system("npm", "run", "build")
@@ -65,7 +65,7 @@ namespace :frontend do
   # This is identical to running bin/rails frontend:build
   # and is provided solely to align better with intent.
   desc "Preview your React App from the Rails development server (typically port 3000)"
-  task preview: [:build]
+  task preview: [ :build ]
 
   # Run bin/rails frontend:clobber to remove the build files.
   # Running bin/rails assets:clobber will also run this task.
@@ -81,5 +81,5 @@ end
 # This means that any normal Rails deployment script which
 # contains rake assets:precompile will also build the
 # React app automatically.
-Rake::Task["assets:precompile"].enhance(["frontend:build"])
-Rake::Task["assets:clobber"].enhance(["frontend:clobber"])
+Rake::Task["assets:precompile"].enhance([ "frontend:build" ])
+Rake::Task["assets:clobber"].enhance([ "frontend:clobber" ])


### PR DESCRIPTION
Issue #48 対応

- lib/tasks/frontend.rake を追加
- naofumi/react-router-vite-rails の react.rake を参考に実装
- namespace を react_router から frontend に変更

追加タスク:
- bin/rails frontend:dev - 開発サーバー起動
- bin/rails frontend:build - プロダクションビルド
- bin/rails frontend:typecheck - TypeScript型チェック
- bin/rails frontend:preview - ビルド & プレビュー
- bin/rails frontend:clobber - ビルドファイル削除
- bin/rails frontend:npm_install - npm パッケージインストール

デプロイ連携:
- assets:precompile で自動的に frontend:build 実行
- assets:clobber で自動的に frontend:clobber 実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>