### PR TITLE
refactor: replace header and danger zone with three-dot menu

### DIFF
--- a/frontend/src/components/QuizControlPanel.tsx
+++ b/frontend/src/components/QuizControlPanel.tsx
@@ -338,10 +338,11 @@ export function QuizControlPanel() {
         mb="40px"
         minH="70vh"
         borderRadius="20px"
+        colorPalette={state?.quizActive ? 'green' : 'red'}
         bgGradient={
           state?.quizActive
-            ? 'linear(135deg, green.100 0%, green.200 100%)'
-            : 'linear(135deg, red.100 0%, red.200 100%)'
+            ? 'linear(135deg, colorPalette.100 0%, colorPalette.200 100%)'
+            : 'linear(135deg, colorPalette.100 0%, colorPalette.200 100%)'
         }
         position="relative"
         p="40px"
@@ -361,7 +362,8 @@ export function QuizControlPanel() {
             <Text
               fontSize={{ base: '32px', md: '40px', lg: '48px' }}
               fontWeight="black"
-              color="gray.800"
+              colorPalette='gray'
+              color="colorPalette.800"
             >
               第 {state.question.questionNumber} 問
             </Text>
@@ -369,7 +371,8 @@ export function QuizControlPanel() {
             <Text
               fontSize={{ base: '32px', md: '40px', lg: '48px' }}
               fontWeight="black"
-              color="gray.800"
+              colorPalette='gray'
+              color="colorPalette.800"
             >
               クイズ待機中
             </Text>
@@ -380,7 +383,8 @@ export function QuizControlPanel() {
             <Text
               fontSize={{ base: '24px', md: '30px', lg: '36px' }}
               fontWeight="bold"
-              color="gray.900"
+              colorPalette='gray'
+              color="colorPalette.900"
               textAlign="center"
               lineHeight="1.5"
               maxW="90%"
@@ -393,7 +397,8 @@ export function QuizControlPanel() {
           <Text
             fontSize={{ base: '80px', md: '120px', lg: '160px' }}
             fontWeight="black"
-            color={state?.questionActive ? 'green.600' : 'gray.400'}
+            colorPalette={state?.questionActive ? (remainingSeconds > 5 ? 'green' : 'red') : 'gray'}
+            color={state?.questionActive ? 'colorPalette.600' : 'colorPalette.400'}
             textAlign="center"
             lineHeight="1"
           >
@@ -405,12 +410,12 @@ export function QuizControlPanel() {
         <Box position="absolute" bottom="20px" right="30px">
           <Stack gap="5px" alignItems="flex-end">
             {state?.questionStartedAt && (
-              <Text fontSize="12px" color="gray.600">
+              <Text fontSize="12px" colorPalette="gray" color="colorPalette.600">
                 開始: {new Date(state.questionStartedAt).toLocaleTimeString()}
               </Text>
             )}
             {state?.questionEndsAt && (
-              <Text fontSize="12px" color="gray.600">
+              <Text fontSize="12px" colorPalette="gray" color="colorPalette.600">
                 終了: {new Date(state.questionEndsAt).toLocaleTimeString()}
               </Text>
             )}

--- a/frontend/src/components/QuizControlPanel.tsx
+++ b/frontend/src/components/QuizControlPanel.tsx
@@ -381,7 +381,7 @@ export function QuizControlPanel() {
           {/* 問題文（中央配置） */}
           {state?.question && (
             <Text
-              fontSize={{ base: '24px', md: '30px', lg: '36px' }}
+              fontSize={{ base: '28px', md: '38px', lg: '48px' }}
               fontWeight="bold"
               colorPalette='gray'
               color="colorPalette.900"

--- a/frontend/src/components/QuizControlPanel.tsx
+++ b/frontend/src/components/QuizControlPanel.tsx
@@ -343,52 +343,60 @@ export function QuizControlPanel() {
             ? 'linear(135deg, green.100 0%, green.200 100%)'
             : 'linear(135deg, red.100 0%, red.200 100%)'
         }
-        display="flex"
-        flexDirection="column"
-        justifyContent="center"
-        alignItems="center"
         position="relative"
         p="40px"
         boxShadow="2xl"
       >
-        {/* 問題番号 */}
-        <Text
-          fontSize={{ base: '60px', md: '90px', lg: '120px' }}
-          fontWeight="black"
-          color={state?.quizActive ? 'green.800' : 'red.800'}
-          mb="20px"
-          textAlign="center"
-          lineHeight="1.2"
-        >
-          {state?.question ? `第 ${state.question.questionNumber} 問` : 'クイズ待機中'}
-        </Text>
-
-        {/* 問題文 */}
+        {/* 問題文（左上配置） */}
         {state?.question && (
-          <Text
-            fontSize={{ base: '24px', md: '30px', lg: '36px' }}
-            fontWeight="bold"
-            color={state?.quizActive ? 'green.700' : 'red.700'}
-            mb="40px"
-            textAlign="center"
-            lineHeight="1.5"
-            maxW="90%"
+          <Box
+            position="absolute"
+            top="30px"
+            left="30px"
+            right="30px"
           >
-            {state.question.content}
-          </Text>
+            <Text
+              fontSize={{ base: '16px', md: '18px', lg: '20px' }}
+              fontWeight="medium"
+              color={state?.quizActive ? 'green.800' : 'red.800'}
+              lineHeight="1.6"
+            >
+              {state.question.content}
+            </Text>
+          </Box>
         )}
 
-        {/* 残り時間 */}
-        <Text
-          fontSize={{ base: '64px', md: '80px', lg: '96px' }}
-          fontWeight="black"
-          color={state?.questionActive ? 'green.600' : 'gray.400'}
-          textAlign="center"
-          lineHeight="1.2"
-          mb="20px"
+        {/* 中央エリア */}
+        <Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+          minH="70vh"
         >
-          残り {remainingSeconds} 秒
-        </Text>
+          {/* 問題番号 */}
+          <Text
+            fontSize={{ base: '60px', md: '90px', lg: '120px' }}
+            fontWeight="black"
+            color={state?.quizActive ? 'green.800' : 'red.800'}
+            mb="40px"
+            textAlign="center"
+            lineHeight="1.2"
+          >
+            {state?.question ? `第 ${state.question.questionNumber} 問` : 'クイズ待機中'}
+          </Text>
+
+          {/* 残り時間（数字のみ） */}
+          <Text
+            fontSize={{ base: '80px', md: '120px', lg: '160px' }}
+            fontWeight="black"
+            color={state?.questionActive ? 'green.600' : 'gray.400'}
+            textAlign="center"
+            lineHeight="1"
+          >
+            {remainingSeconds}
+          </Text>
+        </Box>
 
         {/* 開始時刻・終了時刻（右下に小さく） */}
         <Box position="absolute" bottom="20px" right="30px">

--- a/frontend/src/components/QuizControlPanel.tsx
+++ b/frontend/src/components/QuizControlPanel.tsx
@@ -347,23 +347,6 @@ export function QuizControlPanel() {
         p="40px"
         boxShadow="2xl"
       >
-        {/* 問題番号（左上配置） */}
-        {state?.question && (
-          <Box
-            position="absolute"
-            top="30px"
-            left="30px"
-          >
-            <Text
-              fontSize={{ base: '20px', md: '24px', lg: '28px' }}
-              fontWeight="bold"
-              color={state?.quizActive ? 'green.800' : 'red.800'}
-            >
-              第 {state.question.questionNumber} 問
-            </Text>
-          </Box>
-        )}
-
         {/* 中央エリア */}
         <Box
           display="flex"
@@ -373,12 +356,31 @@ export function QuizControlPanel() {
           minH="70vh"
           gap="40px"
         >
+          {/* 問題番号（中央上部） */}
+          {state?.question ? (
+            <Text
+              fontSize={{ base: '32px', md: '40px', lg: '48px' }}
+              fontWeight="black"
+              color="gray.800"
+            >
+              第 {state.question.questionNumber} 問
+            </Text>
+          ) : (
+            <Text
+              fontSize={{ base: '32px', md: '40px', lg: '48px' }}
+              fontWeight="black"
+              color="gray.800"
+            >
+              クイズ待機中
+            </Text>
+          )}
+
           {/* 問題文（中央配置） */}
           {state?.question && (
             <Text
               fontSize={{ base: '24px', md: '30px', lg: '36px' }}
               fontWeight="bold"
-              color={state?.quizActive ? 'green.700' : 'red.700'}
+              color="gray.900"
               textAlign="center"
               lineHeight="1.5"
               maxW="90%"

--- a/frontend/src/components/QuizControlPanel.tsx
+++ b/frontend/src/components/QuizControlPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useQuery, useMutation } from '@apollo/client/react';
-import { Box, Button, Heading, Text, Stack, SimpleGrid, Card, Badge, Dialog, CloseButton, Portal, HStack } from '@chakra-ui/react';
+import { Box, Button, Heading, Text, Stack, SimpleGrid, Card, Badge, Dialog, CloseButton, Portal, IconButton, Menu } from '@chakra-ui/react';
 import { Toaster, toaster } from "@/components/ui/toaster";
 
 import { GET_CURRENT_QUIZ_STATE, GET_QUESTIONS } from '../graphql/queries';
@@ -290,19 +290,47 @@ export function QuizControlPanel() {
   const isQuizFinished = !state?.quizActive && !state?.questionActive;
 
   return (
-    <Box maxW="1200px" mx="auto" p="20px">
+    <Box maxW="1200px" mx="auto" p="20px" position="relative">
       <Toaster />
 
-      <HStack justifyContent="center" mb="30px" spaceX={6}>
-        <Heading size="xl" ref={currentQuizStateRef} mb={0}>クイズ制御パネル</Heading>
-        <Button
-          variant="outline"
-          onClick={handleLogout}
-          loading={logoutLoading}
-        >
-          ログアウト
-        </Button>
-      </HStack>
+      {/* 3ドットメニュー */}
+      <Box position="absolute" top="20px" right="20px" zIndex={10}>
+        <Menu.Root>
+          <Menu.Trigger asChild>
+            <IconButton
+              variant="ghost"
+              aria-label="メニュー"
+              size="lg"
+            >
+              ⋮
+            </IconButton>
+          </Menu.Trigger>
+          <Menu.Positioner>
+            <Menu.Content>
+              <Box px={4} py={2} fontWeight="bold" color="gray.700">
+                クイズ制御パネル
+              </Box>
+              <Menu.Separator />
+              <Menu.Item
+                value="reset"
+                onClick={() => setIsResetAlertOpen(true)}
+                color="red.600"
+              >
+                全プレイヤーセッションリセット
+              </Menu.Item>
+              <Menu.Item
+                value="logout"
+                onClick={handleLogout}
+                disabled={logoutLoading}
+              >
+                {logoutLoading ? 'ログアウト中...' : 'ログアウト'}
+              </Menu.Item>
+            </Menu.Content>
+          </Menu.Positioner>
+        </Menu.Root>
+      </Box>
+
+      <Box ref={currentQuizStateRef} height="60px" />
 
       {/* クイズ開始ボタン */}
       <Box mb="30px">
@@ -433,27 +461,6 @@ export function QuizControlPanel() {
           ))}
         </SimpleGrid>
       )}
-
-      {/* 危険ゾーン */}
-      <Card.Root mt="30px" bg="red.50" borderColor="red.200" borderWidth="1px">
-        <Card.Header>
-          <Heading size="md" color="red.700">危険ゾーン</Heading>
-        </Card.Header>
-        <Card.Body>
-          <Button
-            colorPalette="red"
-            bg="colorPalette.solid"
-            onClick={() => setIsResetAlertOpen(true)}
-            loading={resetLoading}
-            mb={2}
-          >
-            全プレイヤーセッションをリセット
-          </Button>
-          <Text fontSize="sm" color="gray.600" mb={4}>
-            注意: この操作はすべてのプレイヤーの接続をリセットします。現在のクイズ進行状況には影響しませんが、プレイヤーは再接続が必要になる場合があります。
-          </Text>
-        </Card.Body>
-      </Card.Root>
 
       {/* ランキング表示 */}
       <Box mt="30px">

--- a/frontend/src/components/QuizControlPanel.tsx
+++ b/frontend/src/components/QuizControlPanel.tsx
@@ -347,21 +347,19 @@ export function QuizControlPanel() {
         p="40px"
         boxShadow="2xl"
       >
-        {/* 問題文（左上配置） */}
+        {/* 問題番号（左上配置） */}
         {state?.question && (
           <Box
             position="absolute"
             top="30px"
             left="30px"
-            right="30px"
           >
             <Text
-              fontSize={{ base: '16px', md: '18px', lg: '20px' }}
-              fontWeight="medium"
+              fontSize={{ base: '20px', md: '24px', lg: '28px' }}
+              fontWeight="bold"
               color={state?.quizActive ? 'green.800' : 'red.800'}
-              lineHeight="1.6"
             >
-              {state.question.content}
+              第 {state.question.questionNumber} 問
             </Text>
           </Box>
         )}
@@ -373,18 +371,21 @@ export function QuizControlPanel() {
           justifyContent="center"
           alignItems="center"
           minH="70vh"
+          gap="40px"
         >
-          {/* 問題番号 */}
-          <Text
-            fontSize={{ base: '60px', md: '90px', lg: '120px' }}
-            fontWeight="black"
-            color={state?.quizActive ? 'green.800' : 'red.800'}
-            mb="40px"
-            textAlign="center"
-            lineHeight="1.2"
-          >
-            {state?.question ? `第 ${state.question.questionNumber} 問` : 'クイズ待機中'}
-          </Text>
+          {/* 問題文（中央配置） */}
+          {state?.question && (
+            <Text
+              fontSize={{ base: '24px', md: '30px', lg: '36px' }}
+              fontWeight="bold"
+              color={state?.quizActive ? 'green.700' : 'red.700'}
+              textAlign="center"
+              lineHeight="1.5"
+              maxW="90%"
+            >
+              {state.question.content}
+            </Text>
+          )}
 
           {/* 残り時間（数字のみ） */}
           <Text

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -14,6 +14,7 @@ export const GET_CURRENT_QUIZ_STATE = gql`
       question {
         id
         questionNumber
+        content
       }
     }
   }


### PR DESCRIPTION
- Add three-dot menu (⋮) in top-right corner
- Move "クイズ制御パネル" title to menu header
- Move "全プレイヤーセッションリセット" to menu item
- Move "ログアウト" to menu item
- Remove HStack header with title and logout button
- Remove "危険ゾーン" Card section
- Use Chakra UI v3 Menu components (Menu.Root, Menu.Trigger, etc.)
- Add zIndex and spacing to prevent overlap with quiz control button

🤖 Generated with [Claude Code](https://claude.com/claude-code)