### PR TITLE
feat: implement StartNextQuestionMutation and update button logic

### DIFF
--- a/app/graphql/mutations/start_next_question_mutation.rb
+++ b/app/graphql/mutations/start_next_question_mutation.rb
@@ -1,0 +1,45 @@
+module Mutations
+  class StartNextQuestionMutation < Mutations::BaseMutation
+    description "次の質問を自動的に開始する（管理者用）"
+
+    field :current_quiz_state, Types::CurrentQuizStateType, null: false
+    field :is_last_question, Boolean, null: false, description: "開始した問題が最後の問題かどうか"
+    field :errors, [ String ], null: false
+
+    def resolve
+      require_admin!
+
+      state = CurrentQuizState.instance
+      current_question = state.question
+
+      # 現在の問題がない場合は、最初の問題を開始
+      if current_question.nil?
+        next_question = Question.order(:position).first
+        raise "No questions available" if next_question.nil?
+      else
+        # 次の問題を取得
+        next_question = Question.where("position > ?", current_question.position).order(:position).first
+        raise "No more questions available" if next_question.nil?
+      end
+
+      # 次の問題を開始
+      updated_state = QuizStateManager.start_question(next_question.id)
+
+      # さらに次の問題が存在するかチェック
+      following_question = Question.where("position > ?", next_question.position).order(:position).first
+      is_last = following_question.nil?
+
+      {
+        current_quiz_state: updated_state,
+        is_last_question: is_last,
+        errors: []
+      }
+    rescue StandardError => e
+      {
+        current_quiz_state: CurrentQuizState.instance,
+        is_last_question: false,
+        errors: [ e.message ]
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -3,6 +3,7 @@
 module Types
   class MutationType < Types::BaseObject
     field :start_question, mutation: Mutations::StartQuestionMutation
+    field :start_next_question, mutation: Mutations::StartNextQuestionMutation
     field :submit_answer, mutation: Mutations::SubmitAnswerMutation
     field :admin_login, mutation: Mutations::AdminLoginMutation
     field :admin_logout, mutation: Mutations::AdminLogoutMutation

--- a/frontend/src/components/QuizControlPanel.tsx
+++ b/frontend/src/components/QuizControlPanel.tsx
@@ -494,7 +494,7 @@ export function QuizControlPanel() {
             bg="colorPalette.solid"
             onClick={handleStopQuiz}
             loading={stopQuizLoading}
-            disabled={stopQuizLoading}
+            disabled={stopQuizLoading || state?.questionActive}
             w="100%"
             size="lg"
           >
@@ -506,7 +506,7 @@ export function QuizControlPanel() {
             bg="colorPalette.solid"
             onClick={handleStartNextQuestion}
             loading={startNextLoading}
-            disabled={startNextLoading}
+            disabled={startNextLoading || state?.questionActive}
             w="100%"
             size="lg"
           >

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -53,6 +53,30 @@ export const START_QUESTION = gql`
   }
 `;
 
+// 次の質問を開始（管理者用）
+export const START_NEXT_QUESTION = gql`
+  mutation StartNextQuestion {
+    startNextQuestion(input: {}) {
+      currentQuizState {
+        id
+        quizActive
+        questionActive
+        questionStartedAt
+        questionEndsAt
+        durationSeconds
+        remainingSeconds
+        question {
+          id
+          questionNumber
+          content
+        }
+      }
+      isLastQuestion
+      errors
+    }
+  }
+`;
+
 // 全プレイヤーセッションをリセット
 export const RESET_ALL_PLAYER_SESSIONS = gql`
   mutation ResetAllPlayerSessions {

--- a/test/graphql/mutations/start_next_question_mutation_test.rb
+++ b/test/graphql/mutations/start_next_question_mutation_test.rb
@@ -1,0 +1,214 @@
+require "test_helper"
+require "ostruct"
+require "minitest/mock"
+
+class Mutations::StartNextQuestionMutationTest < ActiveSupport::TestCase
+  def setup
+    @admin = create(:admin)
+    @question1 = create(:question, position: 1)
+    @question2 = create(:question, position: 2)
+    @question3 = create(:question, position: 3)
+
+    state = CurrentQuizState.instance
+    state.update!(quiz_active: true)
+  end
+
+  test "should start next question for admin when not at last question" do
+    # 最初の問題を開始
+    QuizStateManager.start_question(@question1.id)
+    # 問題が終わるまで待つ
+    sleep 0.1
+    QuizStateManager.stop_question
+
+    mutation = <<~GRAPHQL
+      mutation StartNextQuestion {
+        startNextQuestion(input: {}) {
+          currentQuizState {
+            id
+            quizActive
+            questionActive
+            question {
+              id
+              questionNumber
+            }
+          }
+          isLastQuestion
+          errors
+        }
+      }
+    GRAPHQL
+
+    context = { current_admin: @admin }
+    result = Re2qSchema.execute(mutation, variables: {}, context: context)
+
+    assert_empty result.dig("data", "startNextQuestion", "errors"), "GraphQL errors: #{result.dig("data", "startNextQuestion", "errors")&.join(", ")}"
+
+    state = CurrentQuizState.instance
+    state.reload
+
+    assert_equal state.to_gid_param, result.dig("data", "startNextQuestion", "currentQuizState", "id")
+    assert_equal state.quiz_active, result.dig("data", "startNextQuestion", "currentQuizState", "quizActive")
+    assert_equal state.question_active?, result.dig("data", "startNextQuestion", "currentQuizState", "questionActive")
+    assert_equal @question2.to_gid_param, result.dig("data", "startNextQuestion", "currentQuizState", "question", "id")
+    assert_equal @question2.position, result.dig("data", "startNextQuestion", "currentQuizState", "question", "questionNumber")
+    assert_equal false, result.dig("data", "startNextQuestion", "isLastQuestion")
+  end
+
+  test "should start last question and set isLastQuestion to true" do
+    # 2番目の問題を開始
+    QuizStateManager.start_question(@question2.id)
+    sleep 0.1
+    QuizStateManager.stop_question
+
+    mutation = <<~GRAPHQL
+      mutation StartNextQuestion {
+        startNextQuestion(input: {}) {
+          currentQuizState {
+            id
+            question {
+              id
+              questionNumber
+            }
+          }
+          isLastQuestion
+          errors
+        }
+      }
+    GRAPHQL
+
+    context = { current_admin: @admin }
+    result = Re2qSchema.execute(mutation, variables: {}, context: context)
+
+    assert_empty result.dig("data", "startNextQuestion", "errors")
+    assert_equal @question3.to_gid_param, result.dig("data", "startNextQuestion", "currentQuizState", "question", "id")
+    assert_equal true, result.dig("data", "startNextQuestion", "isLastQuestion")
+  end
+
+  test "should start first question when no current question" do
+    mutation = <<~GRAPHQL
+      mutation StartNextQuestion {
+        startNextQuestion(input: {}) {
+          currentQuizState {
+            id
+            question {
+              id
+              questionNumber
+            }
+          }
+          isLastQuestion
+          errors
+        }
+      }
+    GRAPHQL
+
+    context = { current_admin: @admin }
+    result = Re2qSchema.execute(mutation, variables: {}, context: context)
+
+    assert_empty result.dig("data", "startNextQuestion", "errors")
+    assert_equal @question1.to_gid_param, result.dig("data", "startNextQuestion", "currentQuizState", "question", "id")
+    assert_equal false, result.dig("data", "startNextQuestion", "isLastQuestion")
+  end
+
+  test "should not start next question for non-admin" do
+    mutation = <<~GRAPHQL
+      mutation StartNextQuestion {
+        startNextQuestion(input: {}) {
+          currentQuizState {
+            id
+          }
+          isLastQuestion
+          errors
+        }
+      }
+    GRAPHQL
+
+    context = { current_admin: nil }
+    result = Re2qSchema.execute(mutation, variables: {}, context:)
+
+    errors = result.dig("data", "startNextQuestion", "errors")
+    assert_not_nil errors
+    assert_equal "管理者認証が必要です", errors.first
+    assert_equal CurrentQuizState.instance.to_gid_param, result.dig("data", "startNextQuestion", "currentQuizState", "id")
+    assert_equal false, result.dig("data", "startNextQuestion", "isLastQuestion")
+  end
+
+  test "should return errors when no questions available" do
+    # すべての問題を削除
+    Question.destroy_all
+
+    mutation = <<~GRAPHQL
+      mutation StartNextQuestion {
+        startNextQuestion(input: {}) {
+          currentQuizState {
+            id
+          }
+          isLastQuestion
+          errors
+        }
+      }
+    GRAPHQL
+
+    context = { current_admin: @admin }
+    result = Re2qSchema.execute(mutation, variables: {}, context: context)
+
+    errors = result.dig("data", "startNextQuestion", "errors")
+    assert_not_nil errors
+    assert_equal "No questions available", errors.first
+  end
+
+  test "should return errors when no more questions available" do
+    # 最後の問題を開始
+    QuizStateManager.start_question(@question3.id)
+    sleep 0.1
+    QuizStateManager.stop_question
+
+    mutation = <<~GRAPHQL
+      mutation StartNextQuestion {
+        startNextQuestion(input: {}) {
+          currentQuizState {
+            id
+          }
+          isLastQuestion
+          errors
+        }
+      }
+    GRAPHQL
+
+    context = { current_admin: @admin }
+    result = Re2qSchema.execute(mutation, variables: {}, context: context)
+
+    errors = result.dig("data", "startNextQuestion", "errors")
+    assert_not_nil errors
+    assert_equal "No more questions available", errors.first
+  end
+
+  test "should return errors if QuizStateManager fails" do
+    original_start_question = QuizStateManager.method(:start_question)
+    QuizStateManager.define_singleton_method(:start_question) do |question_id|
+      raise StandardError, "QuizStateManager error"
+    end
+
+    begin
+      mutation = <<~GRAPHQL
+        mutation StartNextQuestion {
+          startNextQuestion(input: {}) {
+            currentQuizState {
+              id
+            }
+            isLastQuestion
+            errors
+          }
+        }
+      GRAPHQL
+
+      context = { current_admin: @admin }
+      result = Re2qSchema.execute(mutation, variables: {}, context: context)
+
+      assert_equal [ "QuizStateManager error" ], result.dig("data", "startNextQuestion", "errors")
+      assert_not_nil result.dig("data", "startNextQuestion", "currentQuizState")
+      assert_equal false, result.dig("data", "startNextQuestion", "isLastQuestion")
+    ensure
+      QuizStateManager.define_singleton_method(:start_question, original_start_question)
+    end
+  end
+end


### PR DESCRIPTION
Issue #54 対応

## バックエンド

- `StartNextQuestionMutation` を実装
  - 次の問題を自動的に取得して開始
  - `isLastQuestion` フラグを返却
- `mutation_type.rb` に `start_next_question` フィールドを追加
- 単体テストを実装 (7テストケース)

## フロントエンド

- `START_NEXT_QUESTION` mutation を定義
- `QuizControlPanel` のボタンロジックを変更
  - クイズ未開始: 「クイズ開始」ボタン
  - クイズ開始後: 「次の問題」ボタン
  - 最後の問題開始後: 「クイズ停止」ボタン

🤖 Generated with [Claude Code](https://claude.com/claude-code)