### PR TITLE
feat: accept last answer from players

### DIFF
--- a/app/jobs/persist_answers_job.rb
+++ b/app/jobs/persist_answers_job.rb
@@ -7,84 +7,18 @@ class PersistAnswersJob < ApplicationJob
   # 1秒間隔でループ実行し、question_ends_at を過ぎたら自動停止
   def perform(question_id)
     state = CurrentQuizState.instance
-    question = Question.find(question_id)
 
     # 質問が終了していないかチェック
     if state.question_id != question_id || !state.accepting_answers?
       # 最後の永続化処理を実行してから終了
-      persist_cached_answers(question_id)
+      PersistAnswers.call(question_id: question_id)
       return
     end
 
     # Solid Cache から回答を読み出して DB に永続化
-    persist_cached_answers(question_id)
+    PersistAnswers.call(question_id: question_id)
 
     # 1秒後に再実行
     PersistAnswersJob.set(wait: 1.second).perform_later(question_id)
-  end
-
-  private
-
-  def persist_cached_answers(question_id)
-    # Solid Cache のキーパターン: "answer:#{question_id}:#{player_id}"
-    # Redis の KEYS コマンド相当の機能は Solid Cache にないため、
-    # 回答済みプレイヤーを別途管理する必要がある
-    # ここでは、受付期間中の全プレイヤーのキーをチェックする方式を採用
-
-    # キャッシュから回答を収集
-    cached_answers = collect_cached_answers(question_id)
-    return if cached_answers.empty?
-
-    # DB に一括挿入（重複は無視）
-    bulk_insert_answers(cached_answers)
-
-    # キャッシュから削除（永続化完了後）
-    delete_cached_answers(cached_answers, question_id)
-  end
-
-  def collect_cached_answers(question_id)
-    # Player全体をスキャンするのではなく、キャッシュキーのリストを別途保持
-    # キーリスト: "answer_keys:#{question_id}" (Set型)
-    key_list_key = "answer_keys:#{question_id}"
-    answer_keys = Rails.cache.read(key_list_key) || []
-
-    cached_answers = []
-    answer_keys.each do |cache_key|
-      data = Rails.cache.read(cache_key)
-      cached_answers << data if data
-    end
-
-    cached_answers
-  end
-
-  def bulk_insert_answers(cached_answers)
-    # 重複チェック: player_id と question_id の組み合わせでユニーク制約があるため
-    # insert_all で on_duplicate: :skip を使用
-    Answer.insert_all(
-      cached_answers.map { |data|
-        {
-          player_id: data[:player_id],
-          question_id: data[:question_id],
-          player_answer: data[:player_answer],
-          answered_at: Time.zone.parse(data[:answered_at]),
-          created_at: Time.current,
-          updated_at: Time.current
-        }
-      },
-      unique_by: [ :player_id, :question_id ]
-    )
-  rescue ActiveRecord::RecordNotUnique
-    # ユニーク制約違反は無視（既に挿入済み）
-  end
-
-  def delete_cached_answers(cached_answers, question_id)
-    cached_answers.each do |data|
-      cache_key = "answer:#{question_id}:#{data[:player_id]}"
-      Rails.cache.delete(cache_key)
-    end
-
-    # キーリストもクリア
-    key_list_key = "answer_keys:#{question_id}"
-    Rails.cache.delete(key_list_key)
   end
 end

--- a/app/models/persist_answers.rb
+++ b/app/models/persist_answers.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Solid Cache から回答データを読み出し、DB に永続化するモデル
+# 最後の回答を採用する（回答を更新可能にする）
+class PersistAnswers
+  def self.call(question_id:)
+    new(question_id: question_id).call
+  end
+
+  def initialize(question_id:)
+    @question_id = question_id
+  end
+
+  def call
+    # キャッシュから回答を収集
+    cached_answers = collect_cached_answers
+    return if cached_answers.empty?
+
+    # DB に一括保存（既存の回答は更新）
+    upsert_answers(cached_answers)
+
+    # キャッシュから削除（永続化完了後）
+    delete_cached_answers(cached_answers)
+  end
+
+  private
+
+  attr_reader :question_id
+
+  def collect_cached_answers
+    # キーリスト: "answer_keys:#{question_id}" (Array型)
+    key_list_key = "answer_keys:#{question_id}"
+    answer_keys = Rails.cache.read(key_list_key) || []
+
+    cached_answers = []
+    answer_keys.each do |cache_key|
+      data = Rails.cache.read(cache_key)
+      cached_answers << data if data
+    end
+
+    cached_answers
+  end
+
+  def upsert_answers(cached_answers)
+    # upsert_all を使用して、既存の回答を更新
+    # 最後の回答を採用するため、常に更新する
+    Answer.upsert_all(
+      cached_answers.map { |data|
+        {
+          player_id: data[:player_id],
+          question_id: data[:question_id],
+          player_answer: data[:player_answer],
+          answered_at: Time.zone.parse(data[:answered_at]),
+          created_at: Time.current,
+          updated_at: Time.current
+        }
+      },
+      unique_by: [ :player_id, :question_id ]
+    )
+  rescue ActiveRecord::RecordNotUnique
+    # ユニーク制約違反は無視（念のため）
+  end
+
+  def delete_cached_answers(cached_answers)
+    cached_answers.each do |data|
+      cache_key = "answer:#{question_id}:#{data[:player_id]}"
+      Rails.cache.delete(cache_key)
+    end
+
+    # キーリストもクリア
+    key_list_key = "answer_keys:#{question_id}"
+    Rails.cache.delete(key_list_key)
+  end
+end

--- a/test/jobs/persist_answers_job_test.rb
+++ b/test/jobs/persist_answers_job_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PersistAnswersJobTest < ActiveJob::TestCase
+  setup do
+    @question = create(:question)
+    @state = CurrentQuizState.instance
+    # テスト用のアダプターを設定
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  test "calls PersistAnswers.call with question_id" do
+    # 質問が終了している状態をセット（再実行されないように）
+    @state.update!(question_id: nil)
+
+    # PersistAnswers.call が呼ばれることを確認
+    called_with = nil
+    PersistAnswers.stub :call, ->(args) { called_with = args } do
+      PersistAnswersJob.perform_now(@question.id)
+    end
+
+    assert_equal({ question_id: @question.id }, called_with)
+  end
+
+  test "schedules next job when question is still accepting answers" do
+    # 質問受付中の状態をセット
+    @state.update!(
+      quiz_active: true,
+      question_id: @question.id,
+      question_started_at: Time.current,
+      question_ends_at: 10.seconds.from_now
+    )
+
+    # 次のジョブがスケジュールされることを確認
+    PersistAnswers.stub :call, nil do
+      assert_enqueued_with(job: PersistAnswersJob, args: [ @question.id ], at: 1.second.from_now) do
+        PersistAnswersJob.perform_now(@question.id)
+      end
+    end
+  end
+
+  test "does not schedule next job when question is no longer accepting answers" do
+    # 質問が終了している状態をセット
+    @state.update!(question_id: nil)
+
+    # 次のジョブがスケジュールされないことを確認
+    PersistAnswers.stub :call, nil do
+      assert_no_enqueued_jobs do
+        PersistAnswersJob.perform_now(@question.id)
+      end
+    end
+  end
+
+  test "does not schedule next job when question_id has changed" do
+    # 別の質問に切り替わった状態をセット
+    other_question = create(:question)
+    @state.update!(
+      quiz_active: true,
+      question_id: other_question.id,
+      question_started_at: Time.current,
+      question_ends_at: 10.seconds.from_now
+    )
+
+    # 次のジョブがスケジュールされないことを確認
+    PersistAnswers.stub :call, nil do
+      assert_no_enqueued_jobs do
+        PersistAnswersJob.perform_now(@question.id)
+      end
+    end
+  end
+end

--- a/test/models/persist_answers_test.rb
+++ b/test/models/persist_answers_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PersistAnswersTest < ActiveSupport::TestCase
+  setup do
+    @question = create(:question)
+    @player1 = create(:player)
+    @player2 = create(:player)
+    Rails.cache.clear
+  end
+
+  test "persists cached answers to database" do
+    # キャッシュに回答を保存
+    cache_key1 = "answer:#{@question.id}:#{@player1.id}"
+    cache_key2 = "answer:#{@question.id}:#{@player2.id}"
+
+    Rails.cache.write(cache_key1, {
+      player_id: @player1.id,
+      question_id: @question.id,
+      player_answer: true,
+      answered_at: Time.current.iso8601
+    })
+
+    Rails.cache.write(cache_key2, {
+      player_id: @player2.id,
+      question_id: @question.id,
+      player_answer: false,
+      answered_at: Time.current.iso8601
+    })
+
+    # キーリストを保存
+    Rails.cache.write("answer_keys:#{@question.id}", [ cache_key1, cache_key2 ])
+
+    # PersistAnswers を実行
+    PersistAnswers.call(question_id: @question.id)
+
+    # DBに保存されていることを確認
+    assert_equal 2, Answer.count
+    assert Answer.exists?(player_id: @player1.id, question_id: @question.id, player_answer: true)
+    assert Answer.exists?(player_id: @player2.id, question_id: @question.id, player_answer: false)
+  end
+
+  test "updates existing answer with last answer" do
+    # 既存の回答をDBに保存
+    existing_answer = create(:answer,
+      player: @player1,
+      question: @question,
+      player_answer: true,
+      answered_at: 5.seconds.ago
+    )
+
+    # キャッシュに新しい回答を保存（最後の回答）
+    cache_key = "answer:#{@question.id}:#{@player1.id}"
+    Rails.cache.write(cache_key, {
+      player_id: @player1.id,
+      question_id: @question.id,
+      player_answer: false,  # 変更された回答
+      answered_at: Time.current.iso8601
+    })
+
+    # キーリストを保存
+    Rails.cache.write("answer_keys:#{@question.id}", [ cache_key ])
+
+    # PersistAnswers を実行
+    PersistAnswers.call(question_id: @question.id)
+
+    # DBの回答が更新されていることを確認
+    existing_answer.reload
+    assert_equal false, existing_answer.player_answer
+    assert_equal 1, Answer.count  # 回答は1つだけのまま
+  end
+
+  test "accepts multiple updates and keeps last answer" do
+    # 1回目の回答をキャッシュに保存
+    cache_key = "answer:#{@question.id}:#{@player1.id}"
+    Rails.cache.write(cache_key, {
+      player_id: @player1.id,
+      question_id: @question.id,
+      player_answer: true,
+      answered_at: 3.seconds.ago.iso8601
+    })
+    Rails.cache.write("answer_keys:#{@question.id}", [ cache_key ])
+
+    # 1回目の永続化
+    PersistAnswers.call(question_id: @question.id)
+    assert_equal true, Answer.find_by(player: @player1, question: @question).player_answer
+
+    # 2回目の回答をキャッシュに保存
+    Rails.cache.write(cache_key, {
+      player_id: @player1.id,
+      question_id: @question.id,
+      player_answer: false,
+      answered_at: 2.seconds.ago.iso8601
+    })
+    Rails.cache.write("answer_keys:#{@question.id}", [ cache_key ])
+
+    # 2回目の永続化
+    PersistAnswers.call(question_id: @question.id)
+    assert_equal false, Answer.find_by(player: @player1, question: @question).player_answer
+
+    # 3回目の回答をキャッシュに保存
+    Rails.cache.write(cache_key, {
+      player_id: @player1.id,
+      question_id: @question.id,
+      player_answer: true,
+      answered_at: Time.current.iso8601
+    })
+    Rails.cache.write("answer_keys:#{@question.id}", [ cache_key ])
+
+    # 3回目の永続化
+    PersistAnswers.call(question_id: @question.id)
+
+    # 最後の回答が保存されていることを確認
+    final_answer = Answer.find_by(player: @player1, question: @question)
+    assert_equal true, final_answer.player_answer
+    assert_equal 1, Answer.count  # 回答は1つだけのまま
+  end
+
+  test "deletes cached answers after persistence" do
+    # キャッシュに回答を保存
+    cache_key = "answer:#{@question.id}:#{@player1.id}"
+    Rails.cache.write(cache_key, {
+      player_id: @player1.id,
+      question_id: @question.id,
+      player_answer: true,
+      answered_at: Time.current.iso8601
+    })
+
+    key_list_key = "answer_keys:#{@question.id}"
+    Rails.cache.write(key_list_key, [ cache_key ])
+
+    # PersistAnswers を実行
+    PersistAnswers.call(question_id: @question.id)
+
+    # キャッシュが削除されていることを確認
+    assert_nil Rails.cache.read(cache_key)
+    assert_nil Rails.cache.read(key_list_key)
+  end
+
+  test "handles empty cache gracefully" do
+    # 空のキャッシュで実行
+    assert_nothing_raised do
+      PersistAnswers.call(question_id: @question.id)
+    end
+
+    assert_equal 0, Answer.count
+  end
+
+  test "handles cache with nil answer_keys gracefully" do
+    # answer_keys が nil の場合
+    Rails.cache.write("answer_keys:#{@question.id}", nil)
+
+    assert_nothing_raised do
+      PersistAnswers.call(question_id: @question.id)
+    end
+
+    assert_equal 0, Answer.count
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "minitest/mock"
 
 module ActiveSupport
 class TestCase


### PR DESCRIPTION
## 概要

プレイヤーの最後の回答を採用するように変更しました。これにより、プレイヤーは回答受付期間中に何度でも回答を変更でき、最後に送信した回答が有効になります。

## 変更内容

### 1. `PersistAnswers`モデルの新規作成

- `app/models/persist_answers.rb`を作成
- Solid Cacheから回答データを読み出し、DBに永続化するビジネスロジックを集約
- `upsert_all`を使用して既存の回答を更新（最後の回答を採用）
- `PersistAnswers.call(question_id: question_id)`で呼び出し可能

### 2. `PersistAnswersJob`のリファクタリング

- 薄い層に変更：`PersistAnswers.call`を呼び出すだけに
- 1秒間隔で繰り返し実行
- 質問終了時に自動停止

### 3. テストの追加

- `test/models/persist_answers_test.rb`: 6テスト
  - 回答の永続化
  - 既存回答の更新
  - 複数回の更新と最後の回答の採用
  - キャッシュの削除
  - エッジケースの処理
- `test/jobs/persist_answers_job_test.rb`: 4テスト
  - PersistAnswers.callの呼び出し確認
  - 1秒間隔での繰り返し実行
  - 質問終了時の停止

### 4. テストヘルパーの更新

- `minitest/mock`をrequireして、モック機能を有効化

## 主な仕様変更

**以前**: プレイヤーが最初に回答した結果のみを記録（回答済みは破棄）

**現在**: プレイヤーが最後に回答した結果を記録（回答の更新を許可）

## テスト結果

- 全39テスト成功
- 166アサーション成功
- 既存機能への影響なし

## 設計上のポイント

1. **関心の分離**: ジョブはスケジューリングのみ、ビジネスロジックはモデルに集約
2. **テスト容易性**: モデルとジョブを分離することで、それぞれ独立してテスト可能
3. **TDD**: テストファースト開発により、仕様を明確化してから実装

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)